### PR TITLE
Fix bytesSize reference error in hid_gamepad.py

### DIFF
--- a/hid_gamepad.py
+++ b/hid_gamepad.py
@@ -40,10 +40,10 @@ class Gamepad:
         # report[1] buttons 9-16
         # report[2] buttons 17-24
         # report[3] buttons 25-32
-        self._report = bytearray(bytesSize)
+        self._report = bytearray(reportSize)
         # Remember the last report as well, so we can avoid sending
         # duplicate reports.
-        self._last_report = bytearray(bytesSize)
+        self._last_report = bytearray(reportSize)
         
         # Store settings separately before putting into report. Saves code
         # especially for buttons.


### PR DESCRIPTION
## Pull Request Description:
This pull request addresses a variable reference issue in `hid_gamepad.py`, where `bytesSize` was used instead of `reportSize` for initializing report byte arrays. This caused a `NameError `when running the code.

## Changes Made:
Updated `bytesSize `to `reportSize `in two places:

- `self._report = bytearray(reportSize)`
- `self._last_report = bytearray(reportSize)`

These changes correct the NameError and ensure consistent use of reportSize in the file.